### PR TITLE
Implement lap 2 Item + Explicit S/P Rank rules

### DIFF
--- a/worlds/pizza_tower/Items.py
+++ b/worlds/pizza_tower/Items.py
@@ -15,7 +15,7 @@ def get_item_from_category(category: str) -> list:
 pt_items = {
     "Toppin":                   ("Progression", 101, ItemClassification.progression_skip_balancing),
     "Boss Key":                 ("Progression", 102, ItemClassification.progression),
-    "Lap 2 Portals":            ("Progression", 149, ItemClassification.useful),
+    "Lap 2 Portals":            ("Progression", 149, ItemClassification.progression),
 
     "Mach 4":                   ("Moves Shared", 103, ItemClassification.progression),
     "Uppercut":                 ("Moves Shared", 104, ItemClassification.progression),

--- a/worlds/pizza_tower/Options.py
+++ b/worlds/pizza_tower/Options.py
@@ -257,6 +257,14 @@ class FillerWeights(OptionCounter):
     }
     display_name = "Filler Weights"
 
+class ShuffleLap2(Toggle):
+    """
+    On: Shuffles an item into the pool that enables all lap 2 portals
+
+    Off: Enables all lap 2 portals from the start
+    """
+    display_name = "Shuffle Lap 2 Portals"
+
 class TrapWeights(OptionCounter):
     """
     Determines how often each trap appears in the itempool
@@ -285,7 +293,8 @@ pt_option_groups = [
         Floor3Door,
         Floor4Door,
         Floor5Door,
-        ShuffleBossKeys
+        ShuffleBossKeys,
+        ShuffleLap2
     ]),
     OptionGroup("Extra Checks", [
         TreasureChecks,
@@ -340,6 +349,7 @@ class PTOptions(PerGameCommonOptions):
     move_rando_list: MovesToRandomize
     death_link: DeathLink
     clothing_filler: ClothingFiller
+    shuffle_lap2: ShuffleLap2
     trap_weights: TrapWeights
     filler_weights: FillerWeights
 

--- a/worlds/pizza_tower/Rules.py
+++ b/worlds/pizza_tower/Rules.py
@@ -391,7 +391,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "GOLF S Rank": "SJUMP | CLIMB+GRAB | CLIMB+SLAM",
 
     #The Pig City
-        "The Pig City Complete": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP | UPPER+SLAM+DJUMP",
+        "The Pig City Complete": "SLAM+DJUMP",
         "The Pig City Mushroom Toppin": "NONE",
         "The Pig City Cheese Toppin": "SJUMP | CLIMB",
         "The Pig City Tomato Toppin": "SLAM",
@@ -761,7 +761,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Say Oink!": "SLAM+DJUMP+TAUNT",
         "Chef Task: Pan Fried": "SLAM+DJUMP",
         "Chef Task: Strike!": "SLAM+DJUMP+KICK",
-        "The Pig City S Rank": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP",
+        "The Pig City S Rank": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP | UPPER+SLAM+DJUMP",
 
     #Peppibot Factory
         "Peppibot Factory Complete": "SJUMP+CLIMB+SLAM | SJUMP+UPPER+SLAM",

--- a/worlds/pizza_tower/Rules.py
+++ b/worlds/pizza_tower/Rules.py
@@ -1827,7 +1827,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
     def add_s_rank_rule(lvl: str, location: Location):
         interpret_rule(lvl + " Complete", 0, location) #TODO make this better without making the logic handler freak out
         if options.shuffle_lap2:
-            if options.difficulty != 1 and lvl not in lap1_levels:
+            if options.difficulty == 0 or not (lvl in lap1_levels):
                 add_rule(location, lambda state: state.has("Lap 2 Portals", world.player))
 
     #connect regions

--- a/worlds/pizza_tower/Rules.py
+++ b/worlds/pizza_tower/Rules.py
@@ -54,6 +54,15 @@ rule_moves = {
     "BOMB": "Bomb"
 }
 
+#these levels don't require a second lap on hard difficulty
+lap1_levels = [
+    "Fastfood Saloon",
+    "Gnome Forest",
+    "Peppibot Factory",
+    "Freezerator",
+    "Pizzascare"
+]
+
 def level_gate_rando(world: World, is_noise: bool, logic_type: int) -> list[str]:
     #replace john gutter and pizzascape with any of these levels
     ok_start_levels = [ 
@@ -1818,7 +1827,8 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
     def add_s_rank_rule(lvl: str, location: Location):
         interpret_rule(lvl + " Complete", 0, location) #TODO make this better without making the logic handler freak out
         if options.shuffle_lap2:
-            add_rule(location, lambda state: state.has("Lap 2 Portals", world.player))
+            if options.difficulty != 1 and lvl not in lap1_levels:
+                add_rule(location, lambda state: state.has("Lap 2 Portals", world.player))
 
     #connect regions
     multiworld.get_region("Menu", world.player).connect(multiworld.get_region("Floor 1 Tower Lobby", world.player), "Menu to Floor 1 Tower Lobby")

--- a/worlds/pizza_tower/Rules.py
+++ b/worlds/pizza_tower/Rules.py
@@ -1827,7 +1827,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
     def add_s_rank_rule(lvl: str, location: Location):
         interpret_rule(lvl + " Complete", 0, location) #TODO make this better without making the logic handler freak out
         if options.shuffle_lap2:
-            if options.difficulty == 0 or not (lvl in lap1_levels):
+            if "P Rank" in location.name or options.difficulty == 0 or not (lvl in lap1_levels):
                 add_rule(location, lambda state: state.has("Lap 2 Portals", world.player))
 
     #connect regions

--- a/worlds/pizza_tower/Rules.py
+++ b/worlds/pizza_tower/Rules.py
@@ -54,7 +54,7 @@ rule_moves = {
     "BOMB": "Bomb"
 }
 
-#these levels don't require a second lap on hard difficulty
+#these levels don't require a second lap on expert difficulty
 lap1_levels = [
     "Fastfood Saloon",
     "Gnome Forest",
@@ -201,8 +201,8 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
     #John Gutter
         "John Gutter Complete": "SJUMP | CLIMB",
         "John Gutter Mushroom Toppin": "SJUMP | CLIMB | UPPER | GRAB | SLAM",
-        "John Gutter Cheese Toppin": "SJUMP | CLIMB | UPPER | GRAB",
-        "John Gutter Tomato Toppin": "SJUMP | CLIMB | UPPER | GRAB",
+        "John Gutter Cheese Toppin": "SJUMP | CLIMB | UPPER | GRAB | SLAM",
+        "John Gutter Tomato Toppin": "SJUMP | CLIMB | UPPER | GRAB | SLAM",
         "John Gutter Sausage Toppin": "SJUMP | CLIMB",
         "John Gutter Pineapple Toppin": "SJUMP | CLIMB",
         "John Gutter Secret 1": "SJUMP | CLIMB | UPPER | GRAB | SLAM",
@@ -212,9 +212,10 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: John Gutted": "SJUMP | CLIMB",
         "Chef Task: Primate Rage": "SJUMP | CLIMB",
         "Chef Task: Let's Make This Quick": "SJUMP | CLIMB",
+        "John Gutter S Rank": "SJUMP | CLIMB",
 
     #Pizzascape
-        "Pizzascape Complete": "SJUMP+GRAB | UPPER | GRAB+CLIMB",
+        "Pizzascape Complete": "UPPER+SJUMP | UPPER+CLIMB | GRAB+SJUMP | GRAB+CLIMB",
         "Pizzascape Mushroom Toppin": "NONE",
         "Pizzascape Cheese Toppin": "NONE",
         "Pizzascape Tomato Toppin": "UPPER | GRAB",
@@ -227,6 +228,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Shining Armor": "UPPER | GRAB",
         "Chef Task: Spoonknight": "TAUNT",
         "Chef Task: Spherical": "UPPER | GRAB",
+        "Pizzascape S Rank": "UPPER+SJUMP | UPPER+CLIMB | GRAB+SJUMP | GRAB+CLIMB",
 
     #Ancient Cheese
         "Ancient Cheese Complete": "UPPER+CLIMB+SLAM | UPPER+SJUMP+SLAM | GRAB+CLIMB+SLAM | GRAB+SJUMP+SLAM",
@@ -238,10 +240,11 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Ancient Cheese Secret 1": "NONE",
         "Ancient Cheese Secret 2": "UPPER | GRAB+CLIMB | GRAB+SJUMP",
         "Ancient Cheese Secret 3": "UPPER+SLAM | GRAB+CLIMB+SLAM | GRAB+SJUMP+SLAM",
-        "Ancient Cheese Treasure": "UPPER | GRAB+CLIMB | GRAB+SJUMP",
+        "Ancient Cheese Treasure": "UPPER+CLIMB | UPPER+SJUMP | GRAB+CLIMB | GRAB+SJUMP",
         "Chef Task: Thrill Seeker": "UPPER+CLIMB+SLAM | UPPER+SJUMP+SLAM | GRAB+CLIMB+SLAM | GRAB+SJUMP+SLAM",
         "Chef Task: Volleybomb": "UPPER | GRAB+CLIMB | GRAB+SJUMP",
         "Chef Task: Delicacy": "NONE",
+        "Ancient Cheese S Rank": "UPPER+CLIMB+SLAM | UPPER+SJUMP+SLAM | GRAB+CLIMB+SLAM | GRAB+SJUMP+SLAM",
 
     #Bloodsauce Dungeon
         "Bloodsauce Dungeon Complete": "SJUMP+SLAM | CLIMB+SLAM",
@@ -257,6 +260,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Eruption Man": "SJUMP+SLAM",
         "Chef Task: Very Very Hot Sauce": "SJUMP+SLAM | CLIMB+SLAM",
         "Chef Task: Unsliced Pizzaman": "SJUMP+SLAM | CLIMB+SLAM",
+        "Bloodsauce Dungeon S Rank": "SJUMP+SLAM | CLIMB+SLAM",
 
     #Oregano Desert
         "Oregano Desert Complete": "SJUMP+GRAB | UPPER+GRAB | CLIMB",
@@ -272,6 +276,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Peppino's Rain Dance": "UPPER | SJUMP | CLIMB",
         "Chef Task: Unnecessary Violence": "CLIMB",
         "Chef Task: Alien Cow": "SJUMP+GRAB | UPPER+GRAB | CLIMB",
+        "Oregano Desert S Rank": "SJUMP+GRAB | UPPER+GRAB | CLIMB",
 
     #Wasteyard
         "Wasteyard Complete": "SJUMP | CLIMB",
@@ -287,6 +292,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Alive and Well": "SJUMP | CLIMB",
         "Chef Task: Pretend Ghost": "SJUMP | CLIMB",
         "Chef Task: Ghosted": "SJUMP | CLIMB",
+        "Wasteyard S Rank": "SJUMP | CLIMB",
 
     #Fun Farm
         "Fun Farm Complete": "SLAM+UPPER+GRAB | SLAM+SJUMP | SLAM+CLIMB",
@@ -302,6 +308,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Good Egg": "SLAM+UPPER+GRAB | SLAM+SJUMP | SLAM+CLIMB",
         "Chef Task: No One Is Safe": "SLAM+STAUNT+SJUMP | SLAM+STAUNT+CLIMB",
         "Chef Task: Cube Menace": "SLAM+UPPER | SLAM+SJUMP | SLAM+CLIMB",
+        "Fun Farm S Rank": "SLAM+UPPER+GRAB | SLAM+SJUMP | SLAM+CLIMB",
 
     #Fastfood Saloon
         "Fastfood Saloon Complete": "GRAB+SJUMP | GRAB+CLIMB",
@@ -317,6 +324,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Royal Flush": "GRAB+SJUMP | GRAB+CLIMB",
         "Chef Task: Non-Alcoholic": "GRAB+SJUMP | GRAB+CLIMB",
         "Chef Task: Already Pressed": "GRAB+SJUMP | GRAB+CLIMB",
+        "Fastfood Saloon S Rank": "GRAB+CLIMB",
 
     #Crust Cove
         "Crust Cove Complete": "SLAM+CLIMB | SLAM+SJUMP+UPPER",
@@ -332,6 +340,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Demolition Expert": "SLAM+CLIMB | SLAM+SJUMP+UPPER",
         "Chef Task: Blowback": "SLAM+SJUMP+TAUNT | SLAM+CLIMB+TAUNT",
         "Chef Task: X": "SLAM+SJUMP | SLAM+CLIMB",
+        "Crust Cove S Rank": "SLAM+CLIMB+TAUNT | SLAM+SJUMP+UPPER+TAUNT",
 
     #Gnome Forest
         "Gnome Forest Complete": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP",
@@ -347,10 +356,11 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Bee Nice": "TAUNT",
         "Chef Task: Bullseye": "TAUNT",
         "Chef Task: Lumberjack": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP",
+        "Gnome Forest S Rank": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP",
 
     #Deep-Dish 9
         "Deep-Dish 9 Complete": "SLAM+SJUMP | SLAM+CLIMB",
-        "Deep-Dish 9 Mushroom Toppin": "SLAM+SJUMP | SLAM+CLIMB",
+        "Deep-Dish 9 Mushroom Toppin": "SLAM",
         "Deep-Dish 9 Cheese Toppin": "SLAM+SJUMP | SLAM+CLIMB",
         "Deep-Dish 9 Tomato Toppin": "SLAM+SJUMP | SLAM+CLIMB",
         "Deep-Dish 9 Sausage Toppin": "SLAM+SJUMP | SLAM+CLIMB",
@@ -362,9 +372,10 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Blast 'Em Asteroids": "SLAM+SJUMP | SLAM+CLIMB",
         "Chef Task: Turbo Tunnel": "SLAM+SJUMP | SLAM+CLIMB",
         "Chef Task: Man Meteor": "SLAM+SJUMP | SLAM+CLIMB",
+        "Deep-Dish 9 S Rank": "SLAM+SJUMP | SLAM+CLIMB",
 
     #GOLF
-        "GOLF Complete": "SJUMP | SLAM | CLIMB | UPPER",
+        "GOLF Complete": "NONE",
         "GOLF Mushroom Toppin": "NONE",
         "GOLF Cheese Toppin": "NONE",
         "GOLF Tomato Toppin": "NONE",
@@ -373,13 +384,14 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "GOLF Secret 1": "NONE",
         "GOLF Secret 2": "NONE",
         "GOLF Secret 3": "NONE",
-        "GOLF Treasure": "SJUMP | CLIMB+GRAB",
+        "GOLF Treasure": "SJUMP | CLIMB+GRAB | CLIMB+SLAM",
         "Chef Task: Primo Golfer": "NONE",
         "Chef Task: Helpful Burger": "NONE",
         "Chef Task: Nice Shot": "NONE",
+        "GOLF S Rank": "SJUMP | CLIMB+GRAB | CLIMB+SLAM",
 
     #The Pig City
-        "The Pig City Complete": "SLAM+DJUMP",
+        "The Pig City Complete": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP | UPPER+SLAM+DJUMP",
         "The Pig City Mushroom Toppin": "NONE",
         "The Pig City Cheese Toppin": "SJUMP | CLIMB",
         "The Pig City Tomato Toppin": "SLAM",
@@ -392,21 +404,23 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Say Oink!": "SLAM+DJUMP+TAUNT",
         "Chef Task: Pan Fried": "SLAM+SJUMP | SLAM+CLIMB",
         "Chef Task: Strike!": "SLAM+DJUMP+KICK",
+        "The Pig City S Rank": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP | UPPER+SLAM+DJUMP",
 
     #Peppibot Factory
-        "Peppibot Factory Complete": "SJUMP+UPPER+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
+        "Peppibot Factory Complete": "SJUMP+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
         "Peppibot Factory Mushroom Toppin": "SJUMP | CLIMB+GRAB | CLIMB+UPPER",
-        "Peppibot Factory Cheese Toppin": "SJUMP+UPPER | CLIMB+GRAB | CLIMB+UPPER",
-        "Peppibot Factory Tomato Toppin": "SJUMP+UPPER | CLIMB+GRAB | CLIMB+UPPER",
-        "Peppibot Factory Sausage Toppin": "SJUMP+UPPER | CLIMB+GRAB | CLIMB+UPPER",
-        "Peppibot Factory Pineapple Toppin": "SJUMP+UPPER | CLIMB+GRAB | CLIMB+UPPER",
+        "Peppibot Factory Cheese Toppin": "SJUMP | CLIMB+GRAB | CLIMB+UPPER",
+        "Peppibot Factory Tomato Toppin": "SJUMP | CLIMB+GRAB | CLIMB+UPPER",
+        "Peppibot Factory Sausage Toppin": "SJUMP | CLIMB+GRAB | CLIMB+UPPER",
+        "Peppibot Factory Pineapple Toppin": "SJUMP | CLIMB+GRAB | CLIMB+UPPER",
         "Peppibot Factory Secret 1": "SJUMP | CLIMB",
-        "Peppibot Factory Secret 2": "SJUMP+UPPER | CLIMB+GRAB | CLIMB+UPPER",
-        "Peppibot Factory Secret 3": "SJUMP+UPPER+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
-        "Peppibot Factory Treasure": "SLAM+SJUMP | SLAM+CLIMB",
-        "Chef Task: There Can Be Only One": "SJUMP+UPPER+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
+        "Peppibot Factory Secret 2": "SJUMP | CLIMB+GRAB | CLIMB+UPPER",
+        "Peppibot Factory Secret 3": "SJUMP+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
+        "Peppibot Factory Treasure": "SJUMP+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
+        "Chef Task: There Can Be Only One": "SJUMP+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
         "Chef Task: Whoop This!": "SJUMP | CLIMB+GRAB | CLIMB+UPPER",
-        "Chef Task: Unflattening": "SJUMP+UPPER+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
+        "Chef Task: Unflattening": "SJUMP+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
+        "Peppibot Factory S Rank": "SJUMP+SLAM | CLIMB+GRAB+SLAM | CLIMB+UPPER+SLAM",
 
     #Oh Shit!
         "Oh Shit! Complete": "SLAM+CLIMB",
@@ -422,6 +436,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Food Clan": "SLAM+SJUMP+TAUNT | SLAM+CLIMB+TAUNT | SLAM+UPPER+TAUNT",
         "Chef Task: Can't Fool Me": "SLAM+CLIMB",
         "Chef Task: Penny Pincher": "SLAM+CLIMB",
+        "Oh Shit! S Rank": "SLAM+CLIMB",
 
     #Freezerator
         "Freezerator Complete": "SJUMP+SLAM | CLIMB+SLAM",
@@ -437,6 +452,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Ice Climber": "SJUMP+SLAM | CLIMB+SLAM",
         "Chef Task: Season's Greetings": "SJUMP+SLAM+STAUNT | CLIMB+SLAM+STAUNT",
         "Chef Task: Frozen Nuggets": "SJUMP+SLAM | CLIMB+SLAM",
+        "Freezerator S Rank": "SJUMP+SLAM | CLIMB+SLAM",
 
     #Pizzascare
         "Pizzascare Complete": "SJUMP+SLAM | CLIMB+SLAM",
@@ -452,6 +468,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Haunted Playground": "SJUMP+SLAM | CLIMB+SLAM",
         "Chef Task: Skullsplitter": "SJUMP+SLAM | CLIMB+SLAM",
         "Chef Task: Cross To Bare": "SJUMP+SLAM | CLIMB+SLAM",
+        "Pizzascare S Rank": "SJUMP+SLAM | CLIMB+SLAM",
 
     #Don't Make A Sound
         "Don't Make A Sound Complete": "CLIMB+GRAB | CLIMB+UPPER",
@@ -467,21 +484,23 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Let Them Sleep": "CLIMB+GRAB | CLIMB+UPPER",
         "Chef Task: Jumpspared": "CLIMB+GRAB | CLIMB+UPPER",
         "Chef Task: And This... Is My Gun On A Stick!": "CLIMB+GRAB | CLIMB+UPPER",
+        "Don't Make A Sound S Rank": "CLIMB+GRAB | CLIMB+UPPER",
 
     #WAR
-        "WAR Complete": "GRAB+SLAM+SJUMP | UPPER+SLAM+SJUMP | GRAB+SLAM+CLIMB | UPPER+SLAM+CLIMB",
-        "WAR Mushroom Toppin": "GRAB+SJUMP | GRAB+CLIMB | GRAB+SLAM | UPPER+SJUMP | UPPER+CLIMB | UPPER+SLAM",
-        "WAR Cheese Toppin": "GRAB+SJUMP | GRAB+CLIMB | GRAB+SLAM | UPPER+SJUMP | UPPER+CLIMB | UPPER+SLAM",
-        "WAR Tomato Toppin": "GRAB+SLAM | UPPER+SLAM",
-        "WAR Sausage Toppin": "GRAB+SLAM | UPPER+SLAM",
-        "WAR Pineapple Toppin": "GRAB+SLAM | UPPER+SLAM",
-        "WAR Secret 1": "GRAB+SLAM | UPPER+SLAM",
-        "WAR Secret 2": "GRAB+SLAM | UPPER+SLAM",
-        "WAR Secret 3": "GRAB+SLAM | UPPER+SLAM",
-        "WAR Treasure": "GRAB+SLAM | UPPER+SLAM",
-        "Chef Task: Trip to the Warzone": "GRAB+SLAM+SJUMP | UPPER+SLAM+SJUMP | GRAB+SLAM+CLIMB | UPPER+SLAM+CLIMB",
-        "Chef Task: Sharpshooter": "GRAB+SLAM+SJUMP | UPPER+SLAM+SJUMP | GRAB+SLAM+CLIMB | UPPER+SLAM+CLIMB",
-        "Chef Task: Decorated Veteran": "GRAB+SLAM+SJUMP | UPPER+SLAM+SJUMP | GRAB+SLAM+CLIMB | UPPER+SLAM+CLIMB",
+        "WAR Complete": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Mushroom Toppin": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Cheese Toppin": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Tomato Toppin": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Sausage Toppin": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Pineapple Toppin": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Secret 1": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Secret 2": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Secret 3": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR Treasure": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "Chef Task: Trip to the Warzone": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM+MACH4 | UPPER+SLAM+MACH4",
+        "Chef Task: Sharpshooter": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB",
+        "Chef Task: Decorated Veteran": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
+        "WAR S Rank": "GRAB+SJUMP | GRAB+CLIMB | UPPER+SJUMP | UPPER+CLIMB | GRAB+SLAM | UPPER+SLAM",
 
     #Crumbling Tower of Pizza
         "The Crumbling Tower of Pizza Complete": "GRAB+SLAM+SJUMP | GRAB+SLAM+CLIMB",
@@ -550,6 +569,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: John Gutted": "SJUMP",
         "Chef Task: Primate Rage": "SJUMP",
         "Chef Task: Let's Make This Quick": "SJUMP+MACH4", 
+        "John Gutter S Rank": "SJUMP+SLAM",
 
     #Pizzascape
         "Pizzascape Complete": "GRAB+CLIMB",
@@ -565,6 +585,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Shining Armor": "GRAB",
         "Chef Task: Spoonknight": "TAUNT",
         "Chef Task: Spherical": "GRAB",
+        "Pizzascape S Rank": "GRAB+CLIMB",
 
     #Ancient Cheese
         "Ancient Cheese Complete": "GRAB+SJUMP+SLAM | GRAB+CLIMB+SLAM",
@@ -580,6 +601,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Thrill Seeker": "GRAB+SLAM+CLIMB | GRAB+SLAM+SJUMP",
         "Chef Task: Volleybomb": "GRAB+SLAM+CLIMB | GRAB+SLAM+SJUMP",
         "Chef Task: Delicacy": "NONE",
+        "Ancient Cheese S Rank": "GRAB+SJUMP+SLAM | GRAB+CLIMB+SLAM",
 
     #Bloodsauce Dungeon
         "Bloodsauce Dungeon Complete": "SJUMP+SLAM | CLIMB+SLAM",
@@ -595,6 +617,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Eruption Man": "SJUMP+SLAM",
         "Chef Task: Very Very Hot Sauce": "SJUMP+SLAM | CLIMB+SLAM",
         "Chef Task: Unsliced Pizzaman": "SJUMP+SLAM | CLIMB+SLAM",
+        "Bloodsauce Dungeon S Rank": "SJUMP+SLAM | CLIMB+SLAM",
 
     #Oregano Desert
         "Oregano Desert Complete": "CLIMB",
@@ -610,6 +633,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Peppino's Rain Dance": "SJUMP | CLIMB",
         "Chef Task: Unnecessary Violence": "CLIMB",
         "Chef Task: Alien Cow": "CLIMB",
+        "Oregano Desert S Rank": "CLIMB",
 
     #Wasteyard
         "Wasteyard Complete": "SJUMP | CLIMB",
@@ -625,6 +649,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Alive and Well": "SJUMP | CLIMB",
         "Chef Task: Pretend Ghost": "SJUMP | CLIMB",
         "Chef Task: Ghosted": "SJUMP | CLIMB",
+        "Wasteyard S Rank": "SJUMP | CLIMB",
 
     #Fun Farm
         "Fun Farm Complete": "SLAM+SJUMP | SLAM+CLIMB",
@@ -640,6 +665,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Good Egg": "SLAM+SJUMP | SLAM+CLIMB",
         "Chef Task: No One Is Safe": "SLAM+SJUMP+STAUNT | SLAM+CLIMB+STAUNT",
         "Chef Task: Cube Menace": "SLAM+SJUMP | SLAM+CLIMB | SLAM+UPPER",
+        "Fun Farm S Rank": "SLAM+SJUMP | SLAM+CLIMB",
 
     #Fastfood Saloon
         "Fastfood Saloon Complete": "SJUMP+GRAB+CLIMB",
@@ -655,6 +681,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Royal Flush": "SJUMP+GRAB+CLIMB",
         "Chef Task: Non-Alcoholic": "SJUMP+GRAB+CLIMB",
         "Chef Task: Already Pressed": "SJUMP+GRAB+CLIMB",
+        "Fastfood Saloon S Rank": "SJUMP+GRAB+CLIMB",
 
     #Crust Cove
         "Crust Cove Complete": "CLIMB+SLAM",
@@ -670,6 +697,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Demolition Expert": "CLIMB+SLAM",
         "Chef Task: Blowback": "SJUMP+TAUNT | CLIMB+TAUNT",
         "Chef Task: X": "CLIMB+SLAM",
+        "Crust Cove S Rank": "CLIMB+SLAM+TAUNT",
 
     #Gnome Forest
         "Gnome Forest Complete": "SLAM+DJUMP+SPIN+SJUMP | SLAM+DJUMP+KICK+SJUMP | SLAM+DJUMP+SPIN+CLIMB | SLAM+DJUMP+KICK+CLIMB",
@@ -685,6 +713,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Bee Nice": "TAUNT",
         "Chef Task: Bullseye": "TAUNT",
         "Chef Task: Lumberjack": "SLAM+DJUMP+SPIN+SJUMP | SLAM+DJUMP+KICK+SJUMP | SLAM+DJUMP+SPIN+CLIMB | SLAM+DJUMP+KICK+CLIMB",
+        "Gnome Forest S Rank": "SLAM+DJUMP+SPIN+SJUMP | SLAM+DJUMP+KICK+SJUMP | SLAM+DJUMP+SPIN+CLIMB | SLAM+DJUMP+KICK+CLIMB",
 
     #Deep-Dish 9
         "Deep-Dish 9 Complete": "SLAM+CLIMB",
@@ -700,6 +729,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Blast 'Em Asteroids": "SLAM+CLIMB",
         "Chef Task: Turbo Tunnel": "SLAM+SJUMP | SLAM+CLIMB",
         "Chef Task: Man Meteor": "SLAM+SJUMP | SLAM+CLIMB",
+        "Deep-Dish 9 S Rank": "SLAM+CLIMB",
 
     #GOLF
         "GOLF Complete": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
@@ -711,10 +741,11 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "GOLF Secret 1": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
         "GOLF Secret 2": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
         "GOLF Secret 3": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
-        "GOLF Treasure": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
+        "GOLF Treasure": "GRAB+CLIMB | GRAB+SJUMP",
         "Chef Task: Primo Golfer": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
         "Chef Task: Helpful Burger": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
         "Chef Task: Nice Shot": "GRAB+CLIMB | GRAB+SJUMP | GRAB+UPPER",
+        "GOLF S Rank": "GRAB+CLIMB | GRAB+SJUMP",
 
     #The Pig City
         "The Pig City Complete": "SLAM+DJUMP",
@@ -730,6 +761,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Say Oink!": "SLAM+DJUMP+TAUNT",
         "Chef Task: Pan Fried": "SLAM+DJUMP",
         "Chef Task: Strike!": "SLAM+DJUMP+KICK",
+        "The Pig City S Rank": "SJUMP+SLAM+DJUMP | CLIMB+SLAM+DJUMP",
 
     #Peppibot Factory
         "Peppibot Factory Complete": "SJUMP+CLIMB+SLAM | SJUMP+UPPER+SLAM",
@@ -745,6 +777,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: There Can Be Only One": "SJUMP+CLIMB+SLAM | SJUMP+UPPER+SLAM",
         "Chef Task: Whoop This!": "SJUMP",
         "Chef Task: Unflattening": "SJUMP+CLIMB+SLAM | SJUMP+UPPER+SLAM",
+        "Peppibot Factory S Rank": "SJUMP+CLIMB+SLAM | SJUMP+UPPER+SLAM",
 
     #Oh Shit!
         "Oh Shit! Complete": "SLAM+CLIMB",
@@ -760,6 +793,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Food Clan": "SLAM+CLIMB+TAUNT",
         "Chef Task: Can't Fool Me": "SLAM+CLIMB",
         "Chef Task: Penny Pincher": "SLAM+CLIMB+SJUMP",
+        "Oh Shit! S Rank": "SLAM+CLIMB",
 
     #Freezerator
         "Freezerator Complete": "CLIMB+SLAM+SJUMP",
@@ -775,6 +809,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Ice Climber": "CLIMB+SLAM+SJUMP",
         "Chef Task: Season's Greetings": "CLIMB+SLAM+SJUMP+GRAB+STAUNT",
         "Chef Task: Frozen Nuggets": "CLIMB+SLAM+SJUMP",
+        "Freezerator S Rank": "CLIMB+SLAM+SJUMP",
 
     #Pizzascare
         "Pizzascare Complete": "CLIMB+SLAM",
@@ -790,6 +825,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Haunted Playground": "CLIMB+SLAM",
         "Chef Task: Skullsplitter": "CLIMB+SLAM",
         "Chef Task: Cross To Bare": "CLIMB+SLAM",
+        "Pizzascare S Rank": "CLIMB+SLAM",
 
     #Don't Make A Sound
         "Don't Make A Sound Complete": "CLIMB+SLAM+GRAB | CLIMB+SJUMP+GRAB",
@@ -805,6 +841,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Let Them Sleep": "CLIMB+SLAM+GRAB | CLIMB+SJUMP+GRAB",
         "Chef Task: Jumpspared": "CLIMB+SLAM+GRAB | CLIMB+SJUMP+GRAB",
         "Chef Task: And This... Is My Gun On A Stick!": "CLIMB+SLAM+GRAB | CLIMB+SJUMP+GRAB",
+        "Don't Make A Sound S Rank": "CLIMB+SLAM+GRAB | CLIMB+SJUMP+GRAB",
 
     #WAR
         "WAR Complete": "GRAB+SJUMP+SLAM",
@@ -820,6 +857,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Trip to the Warzone": "GRAB+SJUMP+SLAM",
         "Chef Task: Sharpshooter": "GRAB+SJUMP+SLAM",
         "Chef Task: Decorated Veteran": "GRAB+SJUMP+SLAM",
+        "WAR S Rank": "GRAB+SJUMP+SLAM",
 
     #Crumbling Tower of Pizza
         "The Crumbling Tower of Pizza Complete": "SLAM+SJUMP+CLIMB",
@@ -1034,6 +1072,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: John Gutted": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Primate Rage": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Let's Make This Quick": "SJUMP | UPPER | CRUSH | BOUNCE",
+        "John Gutter S Rank": "SJUMP | UPPER | CRUSH | BOUNCE",
 
     #Pizzascape
         "Pizzascape Complete": "GRAB+SJUMP | UPPER | GRAB+BOUNCE | GRAB+CRUSH",
@@ -1049,6 +1088,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Shining Armor": "GRAB | UPPER",
         "Chef Task: Spoonknight": "TAUNT",
         "Chef Task: Spherical": "GRAB | UPPER",
+        "Pizzascape S Rank": "GRAB+SJUMP | UPPER | GRAB+BOUNCE | GRAB+CRUSH",
 
     #Ancient Cheese
         "Ancient Cheese Complete": "GRAB+SJUMP+SLAM | GRAB+SJUMP+TORN | UPPER+SJUMP+SLAM | UPPER+SJUMP+TORN",
@@ -1064,6 +1104,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Thrill Seeker": "GRAB+SJUMP+SLAM | GRAB+SJUMP+TORN | UPPER+SJUMP+SLAM | UPPER+SJUMP+TORN",
         "Chef Task: Volleybomb": "GRAB+SJUMP | UPPER | GRAB+BOUNCE | GRAB+CRUSH",
         "Chef Task: Delicacy": "NONE",
+        "Ancient Cheese S Rank": "GRAB+SJUMP+SLAM | GRAB+SJUMP+TORN | UPPER+SJUMP+SLAM | UPPER+SJUMP+TORN",
 
     #Bloodsauce Dungeon
         "Bloodsauce Dungeon Complete": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH | SJUMP+BOUNCE",
@@ -1079,6 +1120,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Eruption Man": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH | SJUMP+BOUNCE",
         "Chef Task: Very Very Hot Sauce": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH | SJUMP+BOUNCE",
         "Chef Task: Unsliced Pizzaman": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH | SJUMP+BOUNCE",
+        "Bloodsauce Dungeon S Rank": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH | SJUMP+BOUNCE",
 
     #Oregano Desert
         "Oregano Desert Complete": "SJUMP | UPPER | CRUSH | BOUNCE",
@@ -1087,13 +1129,14 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Oregano Desert Tomato Toppin": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Oregano Desert Sausage Toppin": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Oregano Desert Pineapple Toppin": "SJUMP | UPPER | CRUSH | BOUNCE",
-        "Oregano Desert Secret 1": "CRUSH | SJUMP | BOUNCE",
+        "Oregano Desert Secret 1": "SJUMP | BOUNCE",
         "Oregano Desert Secret 2": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Oregano Desert Secret 3": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Oregano Desert Treasure": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Peppino's Rain Dance": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Unnecessary Violence": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Alien Cow": "SJUMP | UPPER | CRUSH | BOUNCE",
+        "Oregano Desert S Rank": "SJUMP | BOUNCE",
 
     #Wasteyard
         "Wasteyard Complete": "SJUMP | UPPER | CRUSH | BOUNCE",
@@ -1109,6 +1152,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Alive and Well": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Pretend Ghost": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Ghosted": "SJUMP | UPPER | CRUSH | BOUNCE",
+        "Wasteyard S Rank": "SJUMP | UPPER | CRUSH | BOUNCE",
 
     #Fun Farm
         "Fun Farm Complete": "CRUSH | SLAM+UPPER | SLAM+BOUNCE | SLAM+SJUMP",
@@ -1124,6 +1168,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Good Egg": "CRUSH | SLAM+UPPER | SLAM+BOUNCE | SLAM+SJUMP",
         "Chef Task: No One Is Safe": "CRUSH+STAUNT | SLAM+UPPER+STAUNT | SLAM+BOUNCE+STAUNT | SLAM+SJUMP+STAUNT",
         "Chef Task: Cube Menace": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
+        "Fun Farm S Rank": "CRUSH | SLAM+UPPER | SLAM+BOUNCE | SLAM+SJUMP",
 
     #Fastfood Saloon
         "Fastfood Saloon Complete": "SJUMP+GRAB | UPPER+GRAB | CRUSH+GRAB | BOUNCE+GRAB",
@@ -1139,21 +1184,23 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Royal Flush": "SJUMP+GRAB | UPPER+GRAB | CRUSH+GRAB | BOUNCE+GRAB",
         "Chef Task: Non-Alcoholic": "SJUMP+GRAB | UPPER+GRAB | CRUSH+GRAB | BOUNCE+GRAB",
         "Chef Task: Already Pressed": "SJUMP+GRAB | UPPER+GRAB | CRUSH+GRAB | BOUNCE+GRAB",
+        "Fastfood Saloon S Rank": "SJUMP+GRAB | UPPER+GRAB | CRUSH+GRAB | BOUNCE+GRAB",
 
     #Crust Cove
-        "Crust Cove Complete": "SJUMP+CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
-        "Crust Cove Mushroom Toppin": "SJUMP",
-        "Crust Cove Cheese Toppin": "SJUMP",
-        "Crust Cove Tomato Toppin": "SJUMP+CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
-        "Crust Cove Sausage Toppin": "SJUMP+CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
-        "Crust Cove Pineapple Toppin": "SJUMP+CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
-        "Crust Cove Secret 1": "SJUMP",
-        "Crust Cove Secret 2": "SJUMP+CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
-        "Crust Cove Secret 3": "SJUMP+CRUSH+TAUNT | SJUMP+TORN+TAUNT | SJUMP+SLAM+TAUNT | SJUMP+BOUNCE+TAUNT",
-        "Crust Cove Treasure": "SJUMP",
-        "Chef Task: Demolition Expert": "SJUMP+CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
-        "Chef Task: Blowback": "SJUMP+CRUSH+TAUNT | SJUMP+TORN+TAUNT | SJUMP+SLAM+TAUNT | SJUMP+BOUNCE+TAUNT",
-        "Chef Task: X": "SJUMP+CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
+        "Crust Cove Complete": "CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
+        "Crust Cove Mushroom Toppin": "CRUSH | SJUMP",
+        "Crust Cove Cheese Toppin": "CRUSH | SJUMP",
+        "Crust Cove Tomato Toppin": "CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
+        "Crust Cove Sausage Toppin": "CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
+        "Crust Cove Pineapple Toppin": "CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
+        "Crust Cove Secret 1": "CRUSH | SJUMP",
+        "Crust Cove Secret 2": "CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
+        "Crust Cove Secret 3": "CRUSH+TAUNT | SJUMP+TORN+TAUNT | SJUMP+SLAM+TAUNT | SJUMP+BOUNCE+TAUNT",
+        "Crust Cove Treasure": "CRUSH | SJUMP",
+        "Chef Task: Demolition Expert": "CRUSH | SJUMP+TORN | SJUMP+SLAM | SJUMP+BOUNCE",
+        "Chef Task: Blowback": "CRUSH+TAUNT | SJUMP+TAUNT",
+        "Chef Task: X": "CRUSH | SJUMP+SLAM | BOUNCE+SLAM | UPPER+SLAM",
+        "Crust Cove S Rank": "CRUSH+TAUNT | SJUMP+TORN+TAUNT | SJUMP+SLAM+TAUNT | SJUMP+BOUNCE+TAUNT",
 
     #Gnome Forest
         "Gnome Forest Complete": "CRUSH",
@@ -1169,6 +1216,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Bee Nice": "TAUNT",
         "Chef Task: Bullseye": "TAUNT",
         "Chef Task: Lumberjack": "CRUSH",
+        "Gnome Forest S Rank": "CRUSH",
 
     #Deep-Dish 9
         "Deep-Dish 9 Complete": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
@@ -1184,9 +1232,10 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Blast 'Em Asteroids": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
         "Chef Task: Turbo Tunnel": "SJUMP+BOUNCE | SJUMP+TORN | UPPER+BOUNCE | UPPER+TORN | CRUSH",
         "Chef Task: Man Meteor": "SJUMP+SLAM | UPPER+SLAM | CRUSH+SLAM | BOUNCE+SLAM",
+        "Deep-Dish 9 S Rank": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
 
     #GOLF
-        "GOLF Complete": "SJUMP | BOUNCE | UPPER | CRUSH | SLAM",
+        "GOLF Complete": "NONE",
         "GOLF Mushroom Toppin": "NONE",
         "GOLF Cheese Toppin": "NONE",
         "GOLF Tomato Toppin": "NONE",
@@ -1199,6 +1248,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Primo Golfer": "NONE",
         "Chef Task: Helpful Burger": "NONE",
         "Chef Task: Nice Shot": "NONE",
+        "GOLF S Rank": "SJUMP | BOUNCE | CRUSH | UPPER",
 
     #The Pig City
         "The Pig City Complete": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
@@ -1214,9 +1264,10 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Say Oink!": "CRUSH+TAUNT | SLAM+SJUMP+TAUNT | SLAM+BOUNCE+TAUNT | SLAM+UPPER+TAUNT",
         "Chef Task: Pan Fried": "CRUSH | SLAM+SJUMP | SLAM+UPPER | SLAM+BOUNCE",
         "Chef Task: Strike!": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
+        "The Pig City S Rank": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
 
     #Peppibot Factory
-        "Peppibot Factory Complete": "SJUMP | CRUSH | UPPER",
+        "Peppibot Factory Complete": "SJUMP+BOUNCE | SJUMP+TORN | UPPER+BOUNCE | UPPER+TORN | CRUSH",
         "Peppibot Factory Mushroom Toppin": "SJUMP | CRUSH | UPPER",
         "Peppibot Factory Cheese Toppin": "SJUMP | CRUSH | UPPER",
         "Peppibot Factory Tomato Toppin": "SJUMP | CRUSH | UPPER",
@@ -1229,6 +1280,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: There Can Be Only One": "SJUMP+BOUNCE | SJUMP+TORN | UPPER+BOUNCE | UPPER+TORN | CRUSH",
         "Chef Task: Whoop This!": "SJUMP | CRUSH | UPPER",
         "Chef Task: Unflattening": "SJUMP+BOUNCE | SJUMP+TORN | UPPER+BOUNCE | UPPER+TORN | CRUSH",
+        "Peppibot Factory S Rank": "SJUMP+BOUNCE | SJUMP+TORN | UPPER+BOUNCE | UPPER+TORN | CRUSH",
 
     #Oh Shit!
         "Oh Shit! Complete": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
@@ -1244,6 +1296,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Food Clan": "SJUMP+SLAM+TAUNT | SJUMP+TORN+TAUNT | BOUNCE+TAUNT | CRUSH+TAUNT | UPPER+SLAM+TAUNT | UPPER+TORN+TAUNT",
         "Chef Task: Can't Fool Me": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
         "Chef Task: Penny Pincher": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
+        "Oh Shit! S Rank": "SJUMP+SLAM | SJUMP+TORN | BOUNCE | CRUSH | UPPER+SLAM | UPPER+TORN",
 
     #Freezerator
         "Freezerator Complete": "NONE",
@@ -1259,6 +1312,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Ice Climber": "NONE",
         "Chef Task: Season's Greetings": "STAUNT | GRAB",
         "Chef Task: Frozen Nuggets": "NONE",
+        "Freezerator S Rank": "NONE",
 
     #Pizzascare
         "Pizzascare Complete": "CRUSH | SJUMP+SLAM | SJUMP+TORN | UPPER+SLAM | UPPER+TORN | BOUNCE",
@@ -1274,6 +1328,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Haunted Playground": "CRUSH | SJUMP+SLAM | SJUMP+TORN | UPPER+SLAM | UPPER+TORN | BOUNCE",
         "Chef Task: Skullsplitter": "CRUSH | SJUMP+SLAM | SJUMP+TORN | UPPER+SLAM | UPPER+TORN | BOUNCE",
         "Chef Task: Cross To Bare": "CRUSH | SJUMP+SLAM | SJUMP+TORN | UPPER+SLAM | UPPER+TORN | BOUNCE",
+        "Pizzascare S Rank": "CRUSH | SJUMP+SLAM | SJUMP+TORN | UPPER+SLAM | UPPER+TORN | BOUNCE",
 
     #Don't Make A Sound
         "Don't Make A Sound Complete": "SJUMP+GRAB | SJUMP+UPPER | CRUSH+GRAB | CRUSH+UPPER | BOUNCE+GRAB | BOUNCE+UPPER",
@@ -1289,6 +1344,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Let Them Sleep": "SJUMP+GRAB | SJUMP+UPPER | CRUSH+GRAB | CRUSH+UPPER | BOUNCE+GRAB | BOUNCE+UPPER",
         "Chef Task: Jumpspared": "SJUMP+GRAB | SJUMP+UPPER | CRUSH+GRAB | CRUSH+UPPER | BOUNCE+GRAB | BOUNCE+UPPER",
         "Chef Task: And This... Is My Gun On A Stick!": "SJUMP+GRAB | SJUMP+UPPER | CRUSH+GRAB | CRUSH+UPPER | BOUNCE+GRAB | BOUNCE+UPPER",
+        "Don't Make A Sound S Rank": "SJUMP+GRAB | SJUMP+UPPER | CRUSH+GRAB | CRUSH+UPPER | BOUNCE+GRAB | BOUNCE+UPPER",
 
     #WAR
         "WAR Complete": "GRAB+SJUMP | UPPER+SJUMP | GRAB+SLAM | UPPER+SLAM | GRAB+CRUSH | UPPER+CRUSH",
@@ -1302,8 +1358,9 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "WAR Secret 3": "GRAB+CRUSH | GRAB+SJUMP | GRAB+BOUNCE | GRAB+SLAM | UPPER+CRUSH | UPPER+SJUMP | UPPER+BOUNCE | UPPER+SLAM",
         "WAR Treasure": "GRAB+CRUSH | GRAB+SJUMP | GRAB+BOUNCE | GRAB+SLAM | UPPER+CRUSH | UPPER+SJUMP | UPPER+BOUNCE | UPPER+SLAM",
         "Chef Task: Trip to the Warzone": "GRAB+SJUMP | UPPER+SJUMP | GRAB+CRUSH | UPPER+CRUSH",
-        "Chef Task: Sharpshooter": "GRAB+SJUMP | UPPER+SJUMP | GRAB+SLAM | UPPER+SLAM | GRAB+CRUSH | UPPER+CRUSH",
-        "Chef Task: Decorated Veteran": "GRAB+SJUMP | UPPER+SJUMP | GRAB+CRUSH | UPPER+CRUSH",
+        "Chef Task: Sharpshooter": "GRAB+SJUMP | UPPER+SJUMP | GRAB+CRUSH | UPPER+CRUSH",
+        "Chef Task: Decorated Veteran": "GRAB+SJUMP | UPPER+SJUMP | GRAB+SLAM | UPPER+SLAM | GRAB+CRUSH | UPPER+CRUSH",
+        "WAR S Rank": "GRAB+SJUMP | UPPER+SJUMP | GRAB+CRUSH | UPPER+CRUSH",
 
     #Crumbling Tower of Pizza
         "The Crumbling Tower of Pizza Complete": "SJUMP+GRAB+SLAM | SJUMP+GRAB+TORN | SJUMP+GRAB+BOUNCE | CRUSH+GRAB",
@@ -1360,7 +1417,8 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "John Gutter Treasure": "SJUMP",
         "Chef Task: John Gutted": "SJUMP",
         "Chef Task: Primate Rage": "SJUMP",
-        "Chef Task: Let's Make This Quick": "SJUMP",
+        "Chef Task: Let's Make This Quick": "SJUMP+MACH4",
+        "John Gutter S Rank": "SJUMP+SLAM | SJUMP+CRUSH | SJUMP+TORN",
 
     #Pizzascape
         "Pizzascape Complete": "GRAB+UPPER | GRAB+SJUMP | GRAB+BOUNCE | GRAB+CRUSH",
@@ -1376,6 +1434,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Shining Armor": "GRAB+UPPER | GRAB+SJUMP | GRAB+BOUNCE | GRAB+CRUSH",
         "Chef Task: Spoonknight": "TAUNT",
         "Chef Task: Spherical": "GRAB",
+        "Pizzascape S Rank": "GRAB+SJUMP",
 
     #Ancient Cheese
         "Ancient Cheese Complete": "GRAB+SJUMP+SLAM | GRAB+SJUMP+TORN | GRAB+SJUMP+CRUSH",
@@ -1391,6 +1450,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Thrill Seeker": "GRAB+SJUMP+SLAM | GRAB+UPPER+SLAM | GRAB+BOUNCE+SLAM | GRAB+SJUMP+TORN | GRAB+UPPER+TORN | GRAB+BOUNCE+TORN | GRAB+SJUMP+CRUSH | GRAB+UPPER+CRUSH | GRAB+BOUNCE+CRUSH",
         "Chef Task: Volleybomb": "GRAB+SJUMP+SLAM | GRAB+UPPER+SLAM | GRAB+BOUNCE+SLAM | GRAB+SJUMP+TORN | GRAB+UPPER+TORN | GRAB+BOUNCE+TORN | GRAB+SJUMP+CRUSH | GRAB+UPPER+CRUSH | GRAB+BOUNCE+CRUSH",
         "Chef Task: Delicacy": "NONE",
+        "Ancient Cheese S Rank": "GRAB+SJUMP+SLAM | GRAB+SJUMP+TORN | GRAB+SJUMP+CRUSH",
 
     #Bloodsauce Dungeon
         "Bloodsauce Dungeon Complete": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP",
@@ -1406,6 +1466,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Eruption Man": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP",
         "Chef Task: Very Very Hot Sauce": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP",
         "Chef Task: Unsliced Pizzaman": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP",
+        "Bloodsauce Dungeon S Rank": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP",
 
     #Oregano Desert
         "Oregano Desert Complete": "SJUMP | UPPER | CRUSH | BOUNCE",
@@ -1421,6 +1482,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Peppino's Rain Dance": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Unnecessary Violence": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Alien Cow": "SJUMP | UPPER | CRUSH | BOUNCE",
+        "Oregano Desert S Rank": "BOUNCE",
 
     #Wasteyard
         "Wasteyard Complete": "SJUMP | UPPER | BOUNCE",
@@ -1436,6 +1498,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Alive and Well": "SJUMP | UPPER | CRUSH | BOUNCE",
         "Chef Task: Pretend Ghost": "SJUMP | UPPER | BOUNCE",
         "Chef Task: Ghosted": "SJUMP | UPPER | BOUNCE",
+        "Wasteyard S Rank": "SJUMP | BOUNCE",
 
     #Fun Farm
         "Fun Farm Complete": "BOUNCE+SLAM | UPPER+SLAM | SJUMP+SLAM | CRUSH",
@@ -1451,6 +1514,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Good Egg": "BOUNCE+SLAM | UPPER+SLAM | SJUMP+SLAM | CRUSH",
         "Chef Task: No One Is Safe": "BOUNCE+SLAM+STAUNT | UPPER+SLAM+STAUNT | SJUMP+SLAM+STAUNT | CRUSH+STAUNT",
         "Chef Task: Cube Menace": "BOUNCE+SLAM | UPPER+SLAM | SJUMP+SLAM | BOUNCE+TORN | UPPER+TORN | SJUMP+TORN | CRUSH",
+        "Fun Farm S Rank": "BOUNCE+SLAM | UPPER+SLAM | SJUMP+SLAM | CRUSH",
 
     #Fastfood Saloon
         "Fastfood Saloon Complete": "SJUMP+GRAB",
@@ -1466,6 +1530,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Royal Flush": "SJUMP+GRAB",
         "Chef Task: Non-Alcoholic": "SJUMP+GRAB",
         "Chef Task: Already Pressed": "SJUMP+GRAB",
+        "Fastfood Saloon S Rank": "SJUMP+GRAB",
 
     #Crust Cove
         "Crust Cove Complete": "SJUMP+SLAM | SJUMP+CRUSH | SJUMP+TORN",
@@ -1481,6 +1546,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Demolition Expert": "SJUMP+SLAM | SJUMP+CRUSH | SJUMP+TORN",
         "Chef Task: Blowback": "SJUMP+TAUNT",
         "Chef Task: X": "SJUMP+SLAM | SJUMP+CRUSH | SJUMP+TORN",
+        "Crust Cove S Rank": "SJUMP+SLAM+TAUNT | SJUMP+CRUSH+TAUNT | SJUMP+TORN+TAUNT",
 
         #Gnome Forest
         "Gnome Forest Complete": "BOUNCE+CRUSH | SJUMP+CRUSH",
@@ -1496,6 +1562,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Bee Nice": "TAUNT",
         "Chef Task: Bullseye": "TAUNT",
         "Chef Task: Lumberjack": "BOUNCE+CRUSH | SJUMP+CRUSH",
+        "Gnome Forest S Rank": "BOUNCE+CRUSH | SJUMP+CRUSH",
 
     #Deep-Dish 9
         "Deep-Dish 9 Complete": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP | SLAM+BOUNCE | TORN+BOUNCE | CRUSH+BOUNCE | SLAM+UPPER | TORN+UPPER | CRUSH+UPPER",
@@ -1511,6 +1578,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Blast 'Em Asteroids": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP | SLAM+BOUNCE | TORN+BOUNCE | CRUSH+BOUNCE | SLAM+UPPER | TORN+UPPER | CRUSH+UPPER",
         "Chef Task: Turbo Tunnel": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP | SLAM+BOUNCE | TORN+BOUNCE | CRUSH+BOUNCE | SLAM+UPPER | TORN+UPPER | CRUSH+UPPER",
         "Chef Task: Man Meteor": "SLAM+SJUMP | SLAM+BOUNCE | SLAM+UPPER",
+        "Deep-Dish 9 S Rank": "SLAM+SJUMP | TORN+SJUMP | CRUSH+SJUMP | SLAM+BOUNCE | TORN+BOUNCE | CRUSH+BOUNCE | SLAM+UPPER | TORN+UPPER | CRUSH+UPPER",
 
     #GOLF
         "GOLF Complete": "SJUMP+GRAB | CRUSH+GRAB | UPPER+GRAB | BOUNCE+GRAB",
@@ -1526,13 +1594,14 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Primo Golfer": "SJUMP+GRAB | CRUSH+GRAB | UPPER+GRAB | BOUNCE+GRAB",
         "Chef Task: Helpful Burger": "SJUMP+GRAB | CRUSH+GRAB | UPPER+GRAB | BOUNCE+GRAB",
         "Chef Task: Nice Shot": "SJUMP+GRAB | CRUSH+GRAB | UPPER+GRAB | BOUNCE+GRAB",
+        "GOLF S Rank": "SJUMP+GRAB | CRUSH+GRAB | UPPER+GRAB | BOUNCE+GRAB",
 
     #The Pig City
         "The Pig City Complete": "SJUMP+SLAM | CRUSH | BOUNCE+SLAM | UPPER+SLAM",
         "The Pig City Mushroom Toppin": "NONE",
         "The Pig City Cheese Toppin": "SJUMP",
         "The Pig City Tomato Toppin": "SJUMP+SLAM | CRUSH | BOUNCE+SLAM | UPPER+SLAM",
-        "The Pig City Sausage Toppin": "SJUMP+SLAM | BOUNCE+SLAM",
+        "The Pig City Sausage Toppin": "SJUMP+SLAM | BOUNCE+SLAM | SJUMP+CRUSH | BOUNCE+CRUSH",
         "The Pig City Pineapple Toppin": "SJUMP+SLAM | CRUSH | BOUNCE+SLAM | UPPER+SLAM",
         "The Pig City Secret 1": "NONE",
         "The Pig City Secret 2": "SJUMP+SLAM | CRUSH | BOUNCE+SLAM | UPPER+SLAM",
@@ -1541,6 +1610,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Say Oink!": "SJUMP+SLAM+TAUNT | CRUSH+TAUNT | BOUNCE+SLAM+TAUNT | UPPER+SLAM+TAUNT",
         "Chef Task: Pan Fried": "SJUMP+SLAM | CRUSH | BOUNCE+SLAM | UPPER+SLAM",
         "Chef Task: Strike!": "SJUMP+SLAM | CRUSH | BOUNCE+SLAM | UPPER+SLAM",
+        "The Pig City S Rank": "SJUMP+SLAM | SJUMP+CRUSH",
 
     #Peppibot Factory
         "Peppibot Factory Complete": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH",
@@ -1556,6 +1626,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: There Can Be Only One": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH",
         "Chef Task: Whoop This!": "SJUMP",
         "Chef Task: Unflattening": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH",
+        "Peppibot Factory S Rank": "SJUMP+SLAM | SJUMP+TORN | SJUMP+CRUSH",
 
     #Oh Shit!
         "Oh Shit! Complete": "SLAM+BOUNCE | TORN+BOUNCE | SLAM+SJUMP | TORN+SJUMP | SLAM+UPPER | TORN+UPPER | CRUSH+SJUMP | CRUSH+BOUNCE | CRUSH+UPPER",
@@ -1571,6 +1642,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Food Clan": "SLAM+BOUNCE+TAUNT | TORN+BOUNCE+TAUNT | CRUSH+TAUNT | SLAM+SJUMP+TAUNT | TORN+SJUMP+TAUNT | SLAM+UPPER+TAUNT | TORN+UPPER+TAUNT",
         "Chef Task: Can't Fool Me": "SLAM+BOUNCE | TORN+BOUNCE | SLAM+SJUMP | TORN+SJUMP | SLAM+UPPER | TORN+UPPER | CRUSH+SJUMP | CRUSH+BOUNCE | CRUSH+UPPER",
         "Chef Task: Penny Pincher": "SLAM+BOUNCE | TORN+BOUNCE | SLAM+SJUMP | TORN+SJUMP | SLAM+UPPER | TORN+UPPER | CRUSH+SJUMP | CRUSH+BOUNCE | CRUSH+UPPER",
+        "Oh Shit! S Rank": "SLAM+BOUNCE | TORN+BOUNCE | SLAM+SJUMP | TORN+SJUMP | SLAM+UPPER | TORN+UPPER | CRUSH+SJUMP | CRUSH+BOUNCE | CRUSH+UPPER",
 
     #Freezerator
         "Freezerator Complete": "NONE",
@@ -1586,6 +1658,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Ice Climber": "NONE",
         "Chef Task: Season's Greetings": "GRAB",
         "Chef Task: Frozen Nuggets": "NONE",
+        "Freezerator S Rank": "NONE",
 
     #Pizzascare
         "Pizzascare Complete": "SJUMP+SLAM | BOUNCE+SLAM | SJUMP+TORN | BOUNCE+TORN | SJUMP+CRUSH | BOUNCE+CRUSH",
@@ -1601,6 +1674,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Haunted Playground": "SJUMP+SLAM | BOUNCE+SLAM | SJUMP+TORN | BOUNCE+TORN | SJUMP+CRUSH | BOUNCE+CRUSH",
         "Chef Task: Skullsplitter": "SJUMP+SLAM | BOUNCE+SLAM | SJUMP+TORN | BOUNCE+TORN | SJUMP+CRUSH | BOUNCE+CRUSH",
         "Chef Task: Cross To Bare": "SJUMP+SLAM | BOUNCE+SLAM | SJUMP+TORN | BOUNCE+TORN | SJUMP+CRUSH | BOUNCE+CRUSH",
+        "Pizzascare S Rank": "SJUMP+SLAM | BOUNCE+SLAM | SJUMP+TORN | BOUNCE+TORN | SJUMP+CRUSH | BOUNCE+CRUSH",
 
     #Don't Make A Sound
         "Don't Make A Sound Complete": "SJUMP+SLAM+GRAB",
@@ -1616,6 +1690,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Let Them Sleep": "SJUMP+SLAM+GRAB",
         "Chef Task: Jumpspared": "SJUMP+SLAM+GRAB",
         "Chef Task: And This... Is My Gun On A Stick!": "SJUMP+SLAM+GRAB",
+        "Don't Make A Sound S Rank": "SJUMP+SLAM+GRAB",
 
     #WAR
         "WAR Complete": "GRAB+SJUMP+SLAM | GRAB+SJUMP+CRUSH | GRAB+SJUMP+TORN",
@@ -1631,6 +1706,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Trip to the Warzone": "GRAB+SJUMP+SLAM | GRAB+SJUMP+CRUSH | GRAB+SJUMP+TORN",
         "Chef Task: Sharpshooter": "GRAB+SJUMP+SLAM | GRAB+SJUMP+CRUSH | GRAB+SJUMP+TORN",
         "Chef Task: Decorated Veteran": "GRAB+SJUMP+SLAM | GRAB+SJUMP+CRUSH | GRAB+SJUMP+TORN",
+        "WAR S Rank": "GRAB+SJUMP+SLAM | GRAB+SJUMP+CRUSH | GRAB+SJUMP+TORN",
 
     #Crumbling Tower of Pizza
         "The Crumbling Tower of Pizza Complete": "GRAB+SJUMP+SLAM | GRAB+SJUMP+TORN | GRAB+SJUMP+CRUSH",
@@ -1825,7 +1901,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         return False
     
     def add_s_rank_rule(lvl: str, location: Location):
-        interpret_rule(lvl + " Complete", 0, location) #TODO make this better without making the logic handler freak out
+        interpret_rule(lvl + " S Rank", 0, location)
         if options.shuffle_lap2:
             if "P Rank" in location.name or options.difficulty == 0 or not (lvl in lap1_levels):
                 add_rule(location, lambda state: state.has("Lap 2 Portals", world.player))

--- a/worlds/pizza_tower/Rules.py
+++ b/worlds/pizza_tower/Rules.py
@@ -1817,6 +1817,8 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
     
     def add_s_rank_rule(lvl: str, location: Location):
         interpret_rule(lvl + " Complete", 0, location) #TODO make this better without making the logic handler freak out
+        if options.shuffle_lap2:
+            add_rule(location, lambda state: state.has("Lap 2 Portals", world.player))
 
     #connect regions
     multiworld.get_region("Menu", world.player).connect(multiworld.get_region("Floor 1 Tower Lobby", world.player), "Menu to Floor 1 Tower Lobby")

--- a/worlds/pizza_tower/Rules.py
+++ b/worlds/pizza_tower/Rules.py
@@ -1312,7 +1312,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Ice Climber": "NONE",
         "Chef Task: Season's Greetings": "STAUNT | GRAB",
         "Chef Task: Frozen Nuggets": "NONE",
-        "Freezerator S Rank": "NONE",
+        "Freezerator S Rank": "SLAM | CRUSH | TORN | BOUNCE",
 
     #Pizzascare
         "Pizzascare Complete": "CRUSH | SJUMP+SLAM | SJUMP+TORN | UPPER+SLAM | UPPER+TORN | BOUNCE",
@@ -1658,7 +1658,7 @@ def set_rules(multiworld: MultiWorld, world: World, options: PTOptions, toppins:
         "Chef Task: Ice Climber": "NONE",
         "Chef Task: Season's Greetings": "GRAB",
         "Chef Task: Frozen Nuggets": "NONE",
-        "Freezerator S Rank": "NONE",
+        "Freezerator S Rank": "SLAM | CRUSH | TORN | BOUNCE",
 
     #Pizzascare
         "Pizzascare Complete": "SJUMP+SLAM | BOUNCE+SLAM | SJUMP+TORN | BOUNCE+TORN | SJUMP+CRUSH | BOUNCE+CRUSH",

--- a/worlds/pizza_tower/__init__.py
+++ b/worlds/pizza_tower/__init__.py
@@ -161,8 +161,8 @@ class PizzaTowerWorld(World):
 
         if not self.options.shuffle_boss_keys and not self.options.open_world:
             locations_to_fill -= 4
-        #disable for now; unlocking laps is kind of annoying
-        #pizza_itempool.append(self.create_item("Lap 2 Portals"))
+        if self.options.shuffle_lap2:
+            pizza_itempool.append(self.create_item("Lap 2 Portals"))
 
         pep_moves = get_item_from_category("Moves Peppino")
         noise_moves = get_item_from_category("Moves Noise")
@@ -274,5 +274,6 @@ class PizzaTowerWorld(World):
             "cheftask_checks": bool(self.options.cheftask_checks),
             "difficulty": bool(self.options.difficulty),
             "palette_filler": bool(self.options.clothing_filler),
-            "secret_checks": bool(self.options.secret_checks)
+            "secret_checks": bool(self.options.secret_checks),
+            "shuffle_lap2": bool(self.options.shuffle_lap2)
         }


### PR DESCRIPTION
Finishes the lap 2 unlock item, this can be enabled in the options yaml
S and P rank locations will require this item, though in expert difficulty certain levels will be in logic without it since they can be 1-lapped
Fun farm is excluded from this because you will need a lot of extra rules to make it work with move rando
Clientside implementation is already done, will merge that when the PR is accepted

Comes with explicit S/P rank rules and some extra logic fixes I found while implementing those